### PR TITLE
feat: adds bzip2 support; refactors to case statement

### DIFF
--- a/nix/casks/cask2derivation.nix
+++ b/nix/casks/cask2derivation.nix
@@ -1,10 +1,9 @@
-{
-  stdenv,
-  pkgs,
-  fetchurl,
-  lib,
-  cask,
-  ...
+{ stdenv
+, pkgs
+, fetchurl
+, lib
+, cask
+, ...
 }:
 stdenv.mkDerivation rec {
   inherit (cask) pname version;
@@ -14,7 +13,7 @@ stdenv.mkDerivation rec {
     jq
     bzip2
   ];
-  phases = ["unpackPhase" "installPhase"];
+  phases = [ "unpackPhase" "installPhase" ];
   unpackPhase = builtins.readFile ./unpack.sh;
   installPhase = builtins.concatStringsSep "\n" cask.installPhase;
   src = fetchurl {

--- a/nix/casks/unpack.sh
+++ b/nix/casks/unpack.sh
@@ -23,32 +23,32 @@ DESCRIPTION=$(echo "$OUTPUT" | jq -r '.description')
 echo "File $FILE_NAME is $DESCRIPTION ($MIME_TYPE)"
 
 case "$MIME_TYPE" in
-"application/zip")
-    echo "Unzipping $src to $DEST"
-    unzip -d "$TEMP" "$src"
-    echo "Contents of $TEMP:"
-    ls -l "$TEMP"
-    echo "Copying $TEMP to $DEST"
-    cd "$TEMP" && cp -a . "$DEST" && cd "$DEST" || exit 1
-    ;;
-"application/x-bzip2")
-    echo "Unpacking $src to $DEST"
-    bzip2 -d "$TEMP" "$src"
-    echo "Contents of $TEMP:"
-    ls -l "$TEMP"
-    echo "Copying $TEMP to $DEST"
-    cd "$TEMP" && cp -a . "$DEST" && cd "$DEST" || exit 1
-    ;;
-"application/x-apple-diskimage")
-    echo "Attaching $TEMP"
-    echo "Y" | /usr/bin/hdiutil attach -nobrowse -readonly "$src" -mountpoint "$TEMP"
-    MOUNTED=1
-    echo "Contents of $TEMP:"
-    ls -l "$TEMP"
-    echo "Copying $TEMP to $DEST"
-    cd "$TEMP" && cp -a !(Applications) "$DEST/" || exit 1
-    ;;
-*)
-    echo "Unknown type $TYPE"
-    ;;
+    "application/zip")
+        echo "Unzipping $src to $DEST"
+        unzip -d "$TEMP" "$src"
+        echo "Contents of $TEMP:"
+        ls -l "$TEMP"
+        echo "Copying $TEMP to $DEST"
+        cd "$TEMP" && cp -a . "$DEST" && cd "$DEST" || exit 1
+        ;;
+    "application/x-bzip2")
+        echo "Unpacking $src to $DEST"
+        bzip2 -d "$TEMP" "$src"
+        echo "Contents of $TEMP:"
+        ls -l "$TEMP"
+        echo "Copying $TEMP to $DEST"
+        cd "$TEMP" && cp -a . "$DEST" && cd "$DEST" || exit 1
+        ;;
+    "application/x-apple-diskimage")
+        echo "Attaching $TEMP"
+        echo "Y" | /usr/bin/hdiutil attach -nobrowse -readonly "$src" -mountpoint "$TEMP"
+        MOUNTED=1
+        echo "Contents of $TEMP:"
+        ls -l "$TEMP"
+        echo "Copying $TEMP to $DEST"
+        cd "$TEMP" && cp -a !(Applications) "$DEST/" || exit 1
+        ;;
+    *)
+        echo "Unknown type $TYPE"
+        ;;
 esac


### PR DESCRIPTION
In service of installing Mailmate via nix-casks; this PR introduces bzip2 support and a minor refactor to a case statement for "easier" addition of other mime types handlers.