### PR TITLE
fix: use stdenv.hostPlatform.system instead of deprecated system

### DIFF
--- a/nix/casks/default.nix
+++ b/nix/casks/default.nix
@@ -16,6 +16,6 @@
         packagesJson);
     in
     {
-      packages = lib.mkIf (lib.hasSuffix "darwin" system) packages;
+      packages = lib.mkIf (lib.hasSuffix "darwin" stdenv.hostPlatform.system) packages;
     };
 }


### PR DESCRIPTION
The bare `system` attribute in perSystem has been deprecated in favor of `stdenv.hostPlatform.system`. This avoids evaluation warnings with recent nixpkgs versions.